### PR TITLE
Install readiness for NPM

### DIFF
--- a/cliist-install
+++ b/cliist-install
@@ -5,6 +5,16 @@ if [[ -f settings.py ]]; then
 	exit 0
 fi;
 
+if [ "$(uname)" == "Darwin" ]; then
+	which python3 || which brew || echo "cliist requires homebrew to be installed to fetch its dependecies.";
+    which python3 || (which brew && brew install python3);
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+	which python3 || echo "Installer needs to sudo to install python3";
+    which python3 || sudo apt-get install python3 -y;
+elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
+    echo "Error: you\'re on Windows.";
+fi
+
 echo -n "Specify your API token: "
 read token
 sed "s/API_TOKEN=''/API_TOKEN='$token'/g" settings.py.template > settings.py

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "cliist",
+  "version": "1.0.0",
+  "description": "Todoist commandline client",
+  "main": "cliist.py",
+  "scripts": {
+    "test": "echo \"no tests defined\"; exit 1;",
+    "postinstall": "./cliist-install"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ddksr/cliist.git"
+  },
+  "bin": {
+    "cliist": "cliist.py"
+  },
+  "keywords": [
+    "todoist",
+    "task",
+    "todo",
+    "project-management",
+    "cli"
+  ],
+  "author": "Shamasis Bhattacharya <mail@shamasis.net> (=)",
+  "bugs": {
+    "url": "https://github.com/ddksr/cliist/issues"
+  },
+  "homepage": "https://github.com/ddksr/cliist#readme"
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "project-management",
     "cli"
   ],
-  "author": "Shamasis Bhattacharya <mail@shamasis.net> (=)",
   "bugs": {
     "url": "https://github.com/ddksr/cliist/issues"
   },


### PR DESCRIPTION
Hi,

I am not a python expert, so the PR might be rusty.
- This adds a `package.json` with `bin` pointing to `cliist.py` and `postinstall` to run `cliist-install`
- Updated `cliist-install` to check and install python3 on target.

You can easily do `npm publish` on this repo (I can do it for you too.) and it should work seamlessly when anyone does `npm install cliist -g`;

Post that anyone can call `cliist` from terminal on OS X and *nix systems.
